### PR TITLE
fix: Change version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ their functions against potential bugs unique to AWS Lambda SnapStart environmen
 
 Following sections explain how to enable this plugin in your Gradle and Maven projects.
 
-| :exclamation:  Maven repository may not have the artifact available by the time you're reading these instructions. Until it's available, you can clone this repository to your local and run `mvn install` to install this SpotBugs plugin to your local Maven repository. After that you can continue with the setup instructions below.|
-|-----------------------------------------|
-
 ### Gradle Builds
 
 After SpotBugs is [enabled in the Gradle project](https://spotbugs.readthedocs.io/en/latest/gradle.html) declaring a dependency on SnapStart bug scanner is sufficient. 
@@ -28,7 +25,7 @@ spotbugs {
 
 dependencies {
     spotbugs("com.github.spotbugs:spotbugs:4.7.3")
-    spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:0.1")
+    spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:0.1.0")
 }
 ```
 
@@ -55,7 +52,7 @@ Example:
                     <plugin>
                         <groupId>software.amazon.lambda.snapstart</groupId>
                         <artifactId>aws-lambda-snapstart-java-rules</artifactId>
-                        <version>0.1</version>
+                        <version>0.1.0</version>
                     </plugin>
                 </plugins>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>software.amazon.lambda.snapstart</groupId>
   <artifactId>aws-lambda-snapstart-java-rules</artifactId>
-  <version>0.1</version>
+  <version>0.1.0</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>AWS Lambda SnapStart SpotBugs Rules</description>
   <url>https://github.com/aws/aws-lambda-snapstart-java-rules</url>
@@ -41,7 +41,7 @@
     <repository>
       <id>ossrh</id>
       <name>Nexus Release Repository</name>
-      <url>https://aws.oss.sonatype.org/content/repositories/releases</url>
+      <url>https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
@@ -164,6 +164,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.4.1</version>
             <executions>
               <execution>
                 <id>attach-javadoc</id>
@@ -176,6 +177,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
+            <version>3.2.1</version>
             <executions>
               <execution>
                 <id>attach-source</id>


### PR DESCRIPTION
- Change version number to 0.1.0 to be Semantic Version compliant and start from there.
- Fix Sonatype repository URL for AWS
- Add version number to dependencies
- Remove annotation about Maven availability in the README (it's available through Maven now)

*Issue #, if available:*

*Description of changes:*

Tested by running the workflow inside my personal fork and confirming that the library was available on Sonatype staging repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
