### PR TITLE
Added support for UUID.randomUUID().toString() detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>software.amazon.lambda.snapstart</groupId>
   <artifactId>aws-lambda-snapstart-java-rules</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1-SNAPSHOT</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>AWS Lambda SnapStart SpotBugs Rules</description>
   <url>https://github.com/aws/aws-lambda-snapstart-java-rules</url>

--- a/src/main/java/software/amazon/lambda/snapstart/ReturnValueRandomnessPropertyDatabase.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ReturnValueRandomnessPropertyDatabase.java
@@ -14,6 +14,7 @@ public class ReturnValueRandomnessPropertyDatabase extends MethodPropertyDatabas
     private static final Set<MethodDescriptor> ALREADY_KNOWN_PSEUDO_RANDOM_GEN_METHODS = new HashSet<>(Arrays.asList(
             new MethodDescriptor("java/lang/Math", "random", "()D", true),
             new MethodDescriptor("java/util/UUID", "randomUUID", "()Ljava/util/UUID;", true),
+            new MethodDescriptor("java/util/UUID", "toString", "()Ljava/lang/String;"),
             new MethodDescriptor("java/util/Random", "nextInt", "()I"),
             new MethodDescriptor("java/lang/StrictMath", "random", "()D", true)
     ));

--- a/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
+++ b/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
@@ -146,6 +146,12 @@ public class LambdaHandlerInitedWithRandomValueTest extends AbstractSnapStartTes
         assertThat(bugCollection, containsExactly(4, snapStartBugMatcher().inClass(className).build()));
     }
 
+    @Test
+    public void testLambdaWithToString() {
+        BugCollection bugCollection = findBugsInClasses("LambdaWithToString");
+        assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("LambdaWithToString").atField("random").atLine(11).build()));
+    }
+
     // TODO fix all tests using this and remove this method eventually!
     private static void toBeFixed(Executable e) {
         assertThrows(AssertionError.class, e);

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/LambdaWithToString.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/LambdaWithToString.java
@@ -1,0 +1,17 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class LambdaWithToString implements RequestHandler<Map<String,String>, String> {
+
+    private final String random = UUID.randomUUID().toString();
+
+    @Override
+    public String handleRequest(Map<String, String> stringStringMap, Context context) {
+        return random;
+    }
+}


### PR DESCRIPTION
Issue #16 

**Note:** This is a temporary fix. We are currently investigating a permanent fix with the implementation of a custom dataflow analysis.

*Description of changes:*
- Add UUID.randomUUID().toString() to the list of known pseudo random generator methods. 
- Add Lambda class that reproduces the issue.
- Add unit test to make sure the issue is fixed
- Change version number to 0.1.1-SNAPSHOT.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
