### PR TITLE
Visit all fields in Lambda Handler class to support Dependency Injection

### DIFF
--- a/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
@@ -42,7 +42,7 @@ public class ByteCodeIntrospector {
     };
 
     boolean isLambdaHandler(XClass xClass) {
-        return implementsLambdaInterface(xClass) || hasLambdaHandlerMethod(xClass);
+        return implementsLambdaInterface(xClass) || hasLambdaHandlerMethod(xClass) || isLambdaHandlerField(xClass);
     }
 
     boolean hasLambdaHandlerMethod(XClass xClass) {
@@ -57,6 +57,15 @@ public class ByteCodeIntrospector {
             }
 
             if (method.getSignature().startsWith(LAMBDA_STREAMING_HANDLER_SIGNATURE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean isLambdaHandlerField(XClass xClass) {
+        for (String fieldType : CacheLambdaHandlerFields.fieldsToVisit) {
+            if (fieldType.contains(xClass.toString())) {
                 return true;
             }
         }

--- a/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerFields.java
+++ b/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerFields.java
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.lambda.snapstart;
+
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.XClass;
+
+import java.util.List;
+import java.util.HashSet;
+import org.apache.bcel.classfile.Field;
+
+/**
+ * This detector stores fields with the Lambda Handler and Crac resources to be used later
+ * for visiting the classes passed in through dependency injection
+ */
+public class CacheLambdaHandlerFields implements Detector {
+    public static HashSet<String> fieldsToVisit = new HashSet<>();
+    private final ByteCodeIntrospector introspector;
+    private ClassContext classContext;
+    private XClass xClass;
+
+    public CacheLambdaHandlerFields(BugReporter reporter) {
+        introspector = new ByteCodeIntrospector();
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        this.classContext = classContext;
+        this.xClass = classContext.getXClass();
+        if (introspector.isLambdaHandler(xClass)) {
+            Field[] fields = classContext.getJavaClass().getFields();
+            for (Field field : fields) {
+                fieldsToVisit.add(field.getType().toString().replace(".", "/"));
+            }
+        }
+    }
+
+    @Override
+    public void report() {
+        // this is a non-reporting detector
+    }
+}

--- a/src/main/resources/findbugs.xml
+++ b/src/main/resources/findbugs.xml
@@ -16,9 +16,15 @@
                 <Earlier class="software.amazon.lambda.snapstart.BuildRandomReturningMethodsDatabase"/>
                 <Later class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"/>
             </SplitPass>
+            <SplitPass>
+                <Earlier class="software.amazon.lambda.snapstart.CacheLambdaHandlerFields"/>
+                <Later class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"/>
+            </SplitPass>
         </OrderingConstraints>
 
         <Detector class="software.amazon.lambda.snapstart.BuildRandomReturningMethodsDatabase"
+                  speed="fast" reports="" disabled="false" hidden="true"/>
+        <Detector class="software.amazon.lambda.snapstart.CacheLambdaHandlerFields"
                   speed="fast" reports="" disabled="false" hidden="true"/>
         <Detector class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"
                   reports="AWS_LAMBDA_SNAP_START_BUG" />

--- a/src/main/resources/messages.xml
+++ b/src/main/resources/messages.xml
@@ -13,6 +13,12 @@
     </Details>
   </Detector>
 
+  <Detector class="software.amazon.lambda.snapstart.CacheLambdaHandlerFields">
+    <Details>
+      Detector that stores all the fields of the Lambda Handler class to be visited later.
+    </Details>
+  </Detector>
+
   <Detector class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue">
     <Details>
       Main detector to find out SnapStart bugs in Lambda handler classes.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-snapstart-java-rules/issues/14

*Description of changes:*
Visit all fields defined in the Lambda Handler, which should address dependency injection not working.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
