### PR TITLE
Support scanning of classes that implement functional interface

### DIFF
--- a/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
@@ -25,6 +25,7 @@ public class ByteCodeIntrospector {
         add("com.amazonaws.services.lambda.runtime.RequestStreamHandler");
     }};
 
+    private static final String FUNCTIONAL_INTERFACE = "java.util.function.Function";
     private static final String CRAC_RESOURCE_INTERFACE = "org.crac.Resource";
 
     private static final String RANDOM_SIGNATURE = "Ljava/util/Random;";
@@ -71,6 +72,23 @@ public class ByteCodeIntrospector {
         for (ClassDescriptor classDescriptor : xClass.getInterfaceDescriptorList()) {
             try {
                 if (classDescriptor.getXClass().isInterface() && LAMBDA_HANDLER_INTERFACES.contains(classDescriptor.getDottedClassName())) {
+                    return true;
+                }
+            } catch (CheckedAnalysisException e) {
+                // ignore
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This returns true only when the class directly implements
+     * <a href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Function.html">Java Functional Interface</a>.
+     */
+    boolean implementsFunctionalInterface(XClass xClass) {
+        for (ClassDescriptor classDescriptor : xClass.getInterfaceDescriptorList()) {
+            try {
+                if (classDescriptor.getXClass().isInterface() && FUNCTIONAL_INTERFACE.equals(classDescriptor.getDottedClassName())) {
                     return true;
                 }
             } catch (CheckedAnalysisException e) {

--- a/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
+++ b/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
@@ -24,6 +24,7 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
 
     private final BugReporter bugReporter;
     private boolean isLambdaHandlerClass;
+    private boolean implementsFunctionalInterface;
     private boolean isCracResource;
     private boolean inInitializer;
     private boolean inStaticInitializer;
@@ -34,6 +35,7 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
     public LambdaHandlerInitedWithRandomValue(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
         this.isLambdaHandlerClass = false;
+        this.implementsFunctionalInterface = false;
         this.isCracResource = false;
         this.inInitializer = false;
         this.inStaticInitializer = false;
@@ -48,13 +50,14 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
         inCracBeforeCheckpoint = false;
         XClass xClass = getXClass();
         isLambdaHandlerClass = introspector.isLambdaHandler(xClass);
+        implementsFunctionalInterface = introspector.implementsFunctionalInterface(xClass);
         isCracResource = introspector.isCracResource(xClass);
     }
 
     @Override
     public boolean shouldVisitCode(Code code) {
         boolean shouldVisit = false;
-        if (isLambdaHandlerClass) {
+        if (isLambdaHandlerClass || implementsFunctionalInterface) {
             inStaticInitializer = getMethodName().equals(Const.STATIC_INITIALIZER_NAME);
             inInitializer = getMethodName().equals(Const.CONSTRUCTOR_NAME);
             database = Global.getAnalysisCache().getDatabase(ReturnValueRandomnessPropertyDatabase.class);

--- a/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
+++ b/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
@@ -152,6 +152,12 @@ public class LambdaHandlerInitedWithRandomValueTest extends AbstractSnapStartTes
         assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("LambdaWithToString").atField("random").atLine(11).build()));
     }
 
+    @Test
+    public void testClassImplementingFunctionalInterface() {
+        BugCollection bugCollection = findBugsInClasses("ImplementsFunctionalInterface");
+        assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("ImplementsFunctionalInterface").atField("random").atLine(8).build()));
+    }
+
     // TODO fix all tests using this and remove this method eventually!
     private static void toBeFixed(Executable e) {
         assertThrows(AssertionError.class, e);

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/ImplementsFunctionalInterface.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/ImplementsFunctionalInterface.java
@@ -1,0 +1,14 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import java.util.UUID;
+import java.util.function.Function;
+
+public class ImplementsFunctionalInterface implements Function<String, String> {
+
+    private final UUID random = UUID.randomUUID();
+
+    @Override
+    public String apply(String s) {
+        return random.toString();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* [Issue #15](https://github.com/aws/aws-lambda-snapstart-java-rules/issues/15)

Made changes to allow our bug scanner to scan and detect bugs in classes that implement the functional interface. We are currently investigating a more suitable solution by looking for ways to make this configurable (let the customer specify which interface they are using in their project).

*Description of changes:*
- Updated the main detector's shouldVisitCode() method so that it includes classes with functional interface. Now our Bug scanner will not only take into account the Lambda interface(RequestHandler & RequestStreamHandler), but also the java functional interface.
- Add Lambda class that reproduces the issue.
- Add unit test to make sure the issue is fixed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
