### PR TITLE
feat: Visit parents of Lambda classes to catch potential inherited random generators

### DIFF
--- a/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.ba.XClass;
 import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.classfile.Global;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,6 +35,8 @@ public class ByteCodeIntrospector {
     private static final Map<String, Set<String>> TIMESTAMP_METHODS = new HashMap<String, Set<String>>() {{
         put("java.lang.System", setOf("currentTimeMillis", "nanoTime"));
     }};
+
+    private LambdaHandlerParentsDatabase lambdaHandlerParentsDatabase;
 
     private static Set<String> setOf(String ... strings) {
         Set<String> set = new HashSet<>();
@@ -78,6 +81,11 @@ public class ByteCodeIntrospector {
             }
         }
         return false;
+    }
+
+    boolean isLambdaHandlerParentClass(XClass xClass) {
+        lambdaHandlerParentsDatabase = Global.getAnalysisCache().getDatabase(LambdaHandlerParentsDatabase.class);
+        return lambdaHandlerParentsDatabase.getParentClasses().contains(xClass.toString());
     }
 
     /**

--- a/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerParentClasses.java
+++ b/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerParentClasses.java
@@ -1,0 +1,52 @@
+package software.amazon.lambda.snapstart;
+
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.XClass;
+import org.apache.bcel.classfile.JavaClass;
+import edu.umd.cs.findbugs.classfile.Global;
+
+import java.util.Objects;
+
+
+public class CacheLambdaHandlerParentClasses implements Detector {
+
+    private final ByteCodeIntrospector introspector;
+    private ClassContext classContext;
+    private XClass xClass;
+    private final LambdaHandlerParentsDatabase database;
+
+    public CacheLambdaHandlerParentClasses(BugReporter bugReporter) {
+        this.introspector = new ByteCodeIntrospector();
+        database = new LambdaHandlerParentsDatabase();
+        Global.getAnalysisCache().eagerlyPutDatabase(LambdaHandlerParentsDatabase.class, database);
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        this.classContext = classContext;
+        this.xClass = classContext.getXClass();
+        if (introspector.isLambdaHandler(xClass)) {
+            JavaClass[] parentClasses = null;
+            try {
+                parentClasses = classContext.getJavaClass().getSuperClasses();
+            } catch (ClassNotFoundException e) {
+                // Do nothing
+            }
+
+            if (Objects.nonNull(parentClasses)) {
+                for (JavaClass parentClass : parentClasses) {
+                    if (!parentClass.getClassName().equals("java.lang.Object")) {
+                        database.addLambdaParentClass(parentClass.getClassName().replace(".", "/"));
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void report() {
+        // this is a non-reporting detector
+    }
+}

--- a/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
+++ b/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
@@ -24,6 +24,7 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
 
     private final BugReporter bugReporter;
     private boolean isLambdaHandlerClass;
+    private boolean isLambdaHandlerParentClass;
     private boolean isCracResource;
     private boolean inInitializer;
     private boolean inStaticInitializer;
@@ -34,6 +35,7 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
     public LambdaHandlerInitedWithRandomValue(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
         this.isLambdaHandlerClass = false;
+        this.isLambdaHandlerParentClass = false;
         this.isCracResource = false;
         this.inInitializer = false;
         this.inStaticInitializer = false;
@@ -48,13 +50,14 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
         inCracBeforeCheckpoint = false;
         XClass xClass = getXClass();
         isLambdaHandlerClass = introspector.isLambdaHandler(xClass);
+        isLambdaHandlerParentClass = introspector.isLambdaHandlerParentClass(xClass);
         isCracResource = introspector.isCracResource(xClass);
     }
 
     @Override
     public boolean shouldVisitCode(Code code) {
         boolean shouldVisit = false;
-        if (isLambdaHandlerClass) {
+        if (isLambdaHandlerClass || isLambdaHandlerParentClass) {
             inStaticInitializer = getMethodName().equals(Const.STATIC_INITIALIZER_NAME);
             inInitializer = getMethodName().equals(Const.CONSTRUCTOR_NAME);
             database = Global.getAnalysisCache().getDatabase(ReturnValueRandomnessPropertyDatabase.class);

--- a/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerParentsDatabase.java
+++ b/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerParentsDatabase.java
@@ -1,0 +1,17 @@
+package software.amazon.lambda.snapstart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LambdaHandlerParentsDatabase {
+
+    private final List<String> parentClasses = new ArrayList<>();
+
+    public List<String> getParentClasses() {
+        return this.parentClasses;
+    }
+
+    public void addLambdaParentClass(String parentClass) {
+        this.parentClasses.add(parentClass);
+    }
+}

--- a/src/main/resources/findbugs.xml
+++ b/src/main/resources/findbugs.xml
@@ -16,9 +16,15 @@
                 <Earlier class="software.amazon.lambda.snapstart.BuildRandomReturningMethodsDatabase"/>
                 <Later class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"/>
             </SplitPass>
+            <SplitPass>
+                <Earlier class="software.amazon.lambda.snapstart.CacheLambdaHandlerParentClasses"/>
+                <Later class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"/>
+            </SplitPass>
         </OrderingConstraints>
 
         <Detector class="software.amazon.lambda.snapstart.BuildRandomReturningMethodsDatabase"
+                  speed="fast" reports="" disabled="false" hidden="true"/>
+        <Detector class="software.amazon.lambda.snapstart.CacheLambdaHandlerParentClasses"
                   speed="fast" reports="" disabled="false" hidden="true"/>
         <Detector class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"
                   reports="AWS_LAMBDA_SNAP_START_BUG" />

--- a/src/main/resources/messages.xml
+++ b/src/main/resources/messages.xml
@@ -13,6 +13,12 @@
     </Details>
   </Detector>
 
+  <Detector class="software.amazon.lambda.snapstart.CacheLambdaHandlerParentClasses">
+    <Details>
+      Detector that stores parent classes of Lambda Handler classes to be visited later.
+    </Details>
+  </Detector>
+
   <Detector class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue">
     <Details>
       Main detector to find out SnapStart bugs in Lambda handler classes.

--- a/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
+++ b/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
@@ -152,6 +152,13 @@ public class LambdaHandlerInitedWithRandomValueTest extends AbstractSnapStartTes
         assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("LambdaWithToString").atField("random").atLine(11).build()));
     }
 
+    @Test
+    public void testLambdaWithParentClass() {
+        BugCollection bugCollection = findBugsInClasses("LambdaWithParentClass", "ParentHandler", "SuperParentHandler");
+        assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("ParentHandler").atField("parentId").atLine(6).build()));
+        assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("SuperParentHandler").atField("superParentId").atLine(6).build()));
+    }
+
     // TODO fix all tests using this and remove this method eventually!
     private static void toBeFixed(Executable e) {
         assertThrows(AssertionError.class, e);

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/LambdaWithParentClass.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/LambdaWithParentClass.java
@@ -1,0 +1,17 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class LambdaWithParentClass extends ParentHandler implements RequestHandler<String, String> {
+
+    @Override
+    public String handleRequest(String s, Context context) {
+        Logger logger = Logger.getLogger("LambdaWithParentClass");
+        logger.log(Level.INFO, superParentId.toString());
+        return parentId.toString(); 
+    }
+}

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/ParentHandler.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/ParentHandler.java
@@ -1,0 +1,9 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import java.util.UUID;
+
+public abstract class ParentHandler extends SuperParentHandler {
+    protected final UUID parentId = UUID.randomUUID();
+
+    protected ParentHandler() {}
+}

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/SuperParentHandler.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/SuperParentHandler.java
@@ -1,0 +1,9 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import java.util.UUID;
+
+public class SuperParentHandler {
+    protected final UUID superParentId = UUID.randomUUID();
+
+    protected SuperParentHandler() {}
+}


### PR DESCRIPTION
*Issue #, if available:* [Issue #18](https://github.com/aws/aws-lambda-snapstart-java-rules/issues/18)

*Description of changes:* 
- Created a new detector that saves parent classes of lambda handlers so they can be visited by the main detector later to catch potential inherited random generators.
- Updated the main detector to also visit parent classes of lambda handlers
- Added tests to reproduce the issue and to make sure things are working properly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
