### PR TITLE
feat: Scan classes that do not implement an interface

### DIFF
--- a/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
@@ -43,7 +43,29 @@ public class ByteCodeIntrospector {
     };
 
     boolean isLambdaHandler(XClass xClass) {
-        return implementsLambdaInterface(xClass) || hasLambdaHandlerMethod(xClass);
+        return implementsLambdaInterface(xClass) || 
+               hasLambdaHandlerMethod(xClass) || 
+               (hasHandlerInClassName(xClass) && hasHandleRequestMethod(xClass));
+    }
+
+    /**
+     * Returns true if the class has the word "Handler" in the name.
+     */
+    private boolean hasHandlerInClassName(XClass xClass) {
+        return xClass.toString().contains("Handler");
+    }
+
+    /**
+     * Returns true if the class has a method called "handleRequest"
+     */
+    private boolean hasHandleRequestMethod(XClass xClass) {
+        List<? extends XMethod> methods = xClass.getXMethods();
+        for (XMethod method : methods) {
+            if (method.getName().equals("handleRequest")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     boolean hasLambdaHandlerMethod(XClass xClass) {

--- a/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
+++ b/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
@@ -158,6 +158,12 @@ public class LambdaHandlerInitedWithRandomValueTest extends AbstractSnapStartTes
         assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("ImplementsFunctionalInterface").atField("random").atLine(8).build()));
     }
 
+    @Test
+    public void testLambdaWithNoInterface() {
+        BugCollection bugCollection = findBugsInClasses("LambdaHandlerWithNoInterface");
+        assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("LambdaHandlerWithNoInterface").atField("random").atLine(7).build()));
+    }
+
     // TODO fix all tests using this and remove this method eventually!
     private static void toBeFixed(Executable e) {
         assertThrows(AssertionError.class, e);

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/LambdaHandlerWithNoInterface.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/LambdaHandlerWithNoInterface.java
@@ -1,0 +1,12 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import java.util.UUID;
+
+public class LambdaHandlerWithNoInterface {
+
+    private final UUID random = UUID.randomUUID();
+
+    public String handleRequest(){
+        return random.toString();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* [Issue #24](https://github.com/aws/aws-lambda-snapstart-java-rules/issues/24)

*Description of changes:*

As explained [here](https://github.com/aws/aws-lambda-snapstart-java-rules/issues/24), these changes allow our rules to visit classes that do not implement an interface or do not have a method that receives either (Map, com.amazonaws.services.lambda.runtime.Context) or (InputStream, OutputStream, com.amazonaws.services.lambda.runtime.Context) as parameters, but are still valid lambda handler classes.

- Updated the isLambdahandler() method to handle the above-mentioned case.
- Added test class to reproduce the issue
- Added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
