### PR TITLE
feat: Visit all fields in Lambda Handler class to support Dependency Injection

### DIFF
--- a/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
@@ -8,6 +8,10 @@ import edu.umd.cs.findbugs.ba.XClass;
 import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.classfile.FieldDescriptor;
+import edu.umd.cs.findbugs.classfile.Global;
+import org.apache.bcel.generic.Type;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,6 +39,8 @@ public class ByteCodeIntrospector {
     private static final Map<String, Set<String>> TIMESTAMP_METHODS = new HashMap<String, Set<String>>() {{
         put("java.lang.System", setOf("currentTimeMillis", "nanoTime"));
     }};
+
+    private LambdaHandlerFieldsDatabase database;
 
     private static Set<String> setOf(String ... strings) {
         Set<String> set = new HashSet<>();
@@ -95,13 +101,19 @@ public class ByteCodeIntrospector {
                 // ignore
             }
         }
+
+        return false;
     }
 
     /** 
      * This returns true only if this class is used as a field in a Lambda handler class
      */
     boolean isLambdaHandlerField(XClass xClass) {
-        for (String fieldType : CacheLambdaHandlerFields.fieldsToVisit) {
+        database = Global.getAnalysisCache().getDatabase(LambdaHandlerFieldsDatabase.class);
+        for (FieldDescriptor fieldDescriptor : database.getKeys()) {
+            
+
+            String fieldType = Type.getReturnType(fieldDescriptor.getSignature()).toString().replace(".", "/");
             if (fieldType.equals(xClass.toString())) {
                 return true;
             }

--- a/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
@@ -95,6 +95,17 @@ public class ByteCodeIntrospector {
                 // ignore
             }
         }
+    }
+
+    /** 
+     * This returns true only if this class is used as a field in a Lambda handler class
+     */
+    boolean isLambdaHandlerField(XClass xClass) {
+        for (String fieldType : CacheLambdaHandlerFields.fieldsToVisit) {
+            if (fieldType.equals(xClass.toString())) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerFields.java
+++ b/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerFields.java
@@ -4,9 +4,10 @@ import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Detector;
 import edu.umd.cs.findbugs.ba.ClassContext;
 import edu.umd.cs.findbugs.ba.XClass;
+import edu.umd.cs.findbugs.classfile.DescriptorFactory;
+import edu.umd.cs.findbugs.classfile.FieldDescriptor;
+import edu.umd.cs.findbugs.classfile.Global;
 import org.apache.bcel.classfile.Field;
-
-import java.util.HashSet;
 
 /**
  * This detector stores fields with the Lambda Handler and Crac resources to be used later
@@ -14,13 +15,16 @@ import java.util.HashSet;
  */
 public class CacheLambdaHandlerFields implements Detector {
 
-    public static HashSet<String> fieldsToVisit = new HashSet<>();
     private final ByteCodeIntrospector introspector;
     private ClassContext classContext;
     private XClass xClass;
+    private final LambdaHandlerFieldsDatabase database;
+
 
     public CacheLambdaHandlerFields(BugReporter reporter) {
         introspector = new ByteCodeIntrospector();
+        database = new LambdaHandlerFieldsDatabase();
+        Global.getAnalysisCache().eagerlyPutDatabase(LambdaHandlerFieldsDatabase.class, database);
     }
 
     @Override
@@ -30,7 +34,8 @@ public class CacheLambdaHandlerFields implements Detector {
         if (introspector.isLambdaHandler(xClass)) {
             Field[] fields = classContext.getJavaClass().getFields();
             for (Field field : fields) {
-                fieldsToVisit.add(field.getType().toString().replace(".", "/"));
+                FieldDescriptor fieldDescriptor = DescriptorFactory.instance().getFieldDescriptor(xClass.toString().replace(".", "/"), field);
+                database.setProperty(fieldDescriptor, true);
             }
         }
     }

--- a/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerFields.java
+++ b/src/main/java/software/amazon/lambda/snapstart/CacheLambdaHandlerFields.java
@@ -1,0 +1,42 @@
+package software.amazon.lambda.snapstart;
+
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.XClass;
+import org.apache.bcel.classfile.Field;
+
+import java.util.HashSet;
+
+/**
+ * This detector stores fields with the Lambda Handler and Crac resources to be used later
+ * for visiting the classes passed in through dependency injection
+ */
+public class CacheLambdaHandlerFields implements Detector {
+
+    public static HashSet<String> fieldsToVisit = new HashSet<>();
+    private final ByteCodeIntrospector introspector;
+    private ClassContext classContext;
+    private XClass xClass;
+
+    public CacheLambdaHandlerFields(BugReporter reporter) {
+        introspector = new ByteCodeIntrospector();
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        this.classContext = classContext;
+        this.xClass = classContext.getXClass();
+        if (introspector.isLambdaHandler(xClass)) {
+            Field[] fields = classContext.getJavaClass().getFields();
+            for (Field field : fields) {
+                fieldsToVisit.add(field.getType().toString().replace(".", "/"));
+            }
+        }
+    }
+
+    @Override
+    public void report() {
+        // this is a non-reporting detector
+    }
+}

--- a/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerFieldsDatabase.java
+++ b/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerFieldsDatabase.java
@@ -1,0 +1,22 @@
+package software.amazon.lambda.snapstart;
+
+import edu.umd.cs.findbugs.ba.interproc.FieldPropertyDatabase;
+import edu.umd.cs.findbugs.ba.interproc.PropertyDatabaseFormatException;
+
+public class LambdaHandlerFieldsDatabase extends FieldPropertyDatabase<Boolean> {
+
+    public LambdaHandlerFieldsDatabase() {
+        super();
+    }
+
+    @Override
+    protected Boolean decodeProperty(String s) throws PropertyDatabaseFormatException {
+        return null;
+    }
+
+    @Override
+    protected String encodeProperty(Boolean aBoolean) {
+        return null;
+    }
+
+}

--- a/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
+++ b/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
@@ -25,6 +25,7 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
     private final BugReporter bugReporter;
     private boolean isLambdaHandlerClass;
     private boolean implementsFunctionalInterface;
+    private boolean isLambdaHandlerField;
     private boolean isCracResource;
     private boolean inInitializer;
     private boolean inStaticInitializer;
@@ -36,6 +37,7 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
         this.bugReporter = bugReporter;
         this.isLambdaHandlerClass = false;
         this.implementsFunctionalInterface = false;
+        this.isLambdaHandlerField = false;
         this.isCracResource = false;
         this.inInitializer = false;
         this.inStaticInitializer = false;
@@ -51,13 +53,14 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
         XClass xClass = getXClass();
         isLambdaHandlerClass = introspector.isLambdaHandler(xClass);
         implementsFunctionalInterface = introspector.implementsFunctionalInterface(xClass);
+        isLambdaHandlerField = introspector.isLambdaHandlerField(xClass);
         isCracResource = introspector.isCracResource(xClass);
     }
 
     @Override
     public boolean shouldVisitCode(Code code) {
         boolean shouldVisit = false;
-        if (isLambdaHandlerClass || implementsFunctionalInterface) {
+        if (isLambdaHandlerClass || implementsFunctionalInterface || isLambdaHandlerField) {
             inStaticInitializer = getMethodName().equals(Const.STATIC_INITIALIZER_NAME);
             inInitializer = getMethodName().equals(Const.CONSTRUCTOR_NAME);
             database = Global.getAnalysisCache().getDatabase(ReturnValueRandomnessPropertyDatabase.class);

--- a/src/main/resources/findbugs.xml
+++ b/src/main/resources/findbugs.xml
@@ -16,9 +16,15 @@
                 <Earlier class="software.amazon.lambda.snapstart.BuildRandomReturningMethodsDatabase"/>
                 <Later class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"/>
             </SplitPass>
+            <SplitPass>
+                <Earlier class="software.amazon.lambda.snapstart.CacheLambdaHandlerFields"/>
+                <Later class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"/>
+            </SplitPass>
         </OrderingConstraints>
 
         <Detector class="software.amazon.lambda.snapstart.BuildRandomReturningMethodsDatabase"
+                  speed="fast" reports="" disabled="false" hidden="true"/>
+        <Detector class="software.amazon.lambda.snapstart.CacheLambdaHandlerFields"
                   speed="fast" reports="" disabled="false" hidden="true"/>
         <Detector class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue"
                   reports="AWS_LAMBDA_SNAP_START_BUG" />

--- a/src/main/resources/messages.xml
+++ b/src/main/resources/messages.xml
@@ -13,6 +13,12 @@
     </Details>
   </Detector>
 
+  <Detector class="software.amazon.lambda.snapstart.CacheLambdaHandlerFields">
+    <Details>
+      Detector that stores all the fields of the Lambda Handler class to be visited later.
+    </Details>
+  </Detector>
+
   <Detector class="software.amazon.lambda.snapstart.LambdaHandlerInitedWithRandomValue">
     <Details>
       Main detector to find out SnapStart bugs in Lambda handler classes.

--- a/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
+++ b/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
@@ -158,6 +158,12 @@ public class LambdaHandlerInitedWithRandomValueTest extends AbstractSnapStartTes
         assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("ImplementsFunctionalInterface").atField("random").atLine(8).build()));
     }
 
+    @Test
+    public void testLambdaWithDependencyInjection() {
+        BugCollection bugCollection = findBugsInClasses("DependencyInjection", "MyDependency");
+        assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("MyDependency").atField("random").atLine(6).build()));
+    }
+
     // TODO fix all tests using this and remove this method eventually!
     private static void toBeFixed(Executable e) {
         assertThrows(AssertionError.class, e);

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/DependencyInjection.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/DependencyInjection.java
@@ -1,0 +1,16 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class DependencyInjection implements RequestHandler<String, String> {
+    private final MyDependency myDependency;
+
+    public DependencyInjection(MyDependency myDependency) {
+        this.myDependency = myDependency;
+    }
+    @Override
+    public String handleRequest(String s, Context context) {
+        return myDependency.getUUID().toString();
+    }
+}

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/MyDependency.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/MyDependency.java
@@ -1,0 +1,11 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import java.util.UUID;
+
+public class MyDependency {
+    private final UUID random = UUID.randomUUID();
+
+    public UUID getUUID() {
+        return random;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* Issue https://github.com/aws/aws-lambda-snapstart-java-rules/issues/14

*Description of changes:*

    1. Created a first-pass detector to get and cache all field types defined in Lambda Handlers
    2. Updated the main detector to also visit classes associated to the fields mentioned above
    3. Added tests to reproduce the issue and to make sure things are working properly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
