### PR TITLE
fix: Detect combination of Dependency Injection and Functional Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ spotbugs {
 
 dependencies {
     spotbugs("com.github.spotbugs:spotbugs:4.7.3")
-    spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:0.2.0")
+    spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:0.2.1")
 }
 ```
 
@@ -52,7 +52,7 @@ Example:
                     <plugin>
                         <groupId>software.amazon.lambda.snapstart</groupId>
                         <artifactId>aws-lambda-snapstart-java-rules</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.2.1</version>
                     </plugin>
                 </plugins>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>software.amazon.lambda.snapstart</groupId>
   <artifactId>aws-lambda-snapstart-java-rules</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>AWS Lambda SnapStart SpotBugs Rules</description>
   <url>https://github.com/aws/aws-lambda-snapstart-java-rules</url>

--- a/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
+++ b/src/main/java/software/amazon/lambda/snapstart/ByteCodeIntrospector.java
@@ -51,7 +51,8 @@ public class ByteCodeIntrospector {
     };
 
     boolean isLambdaHandler(XClass xClass) {
-        return implementsLambdaInterface(xClass) || 
+        return implementsLambdaInterface(xClass) ||
+               implementsFunctionalInterface(xClass) ||
                hasLambdaHandlerMethod(xClass) || 
                (hasHandlerInClassName(xClass) && hasHandleRequestMethod(xClass));
     }

--- a/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
+++ b/src/main/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValue.java
@@ -63,7 +63,7 @@ public class LambdaHandlerInitedWithRandomValue extends OpcodeStackDetector {
     @Override
     public boolean shouldVisitCode(Code code) {
         boolean shouldVisit = false;
-        if (isLambdaHandlerClass || implementsFunctionalInterface || isLambdaHandlerField || isLambdaHandlerParentClass) {
+        if (isLambdaHandlerClass || isLambdaHandlerField || isLambdaHandlerParentClass) {
             inStaticInitializer = getMethodName().equals(Const.STATIC_INITIALIZER_NAME);
             inInitializer = getMethodName().equals(Const.CONSTRUCTOR_NAME);
             database = Global.getAnalysisCache().getDatabase(ReturnValueRandomnessPropertyDatabase.class);

--- a/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
+++ b/src/test/java/software/amazon/lambda/snapstart/LambdaHandlerInitedWithRandomValueTest.java
@@ -177,6 +177,13 @@ public class LambdaHandlerInitedWithRandomValueTest extends AbstractSnapStartTes
         assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("MyDependency").atField("random").atLine(6).build()));
     }
 
+    // Test a Lambda function using Dependency Injection while implementing a Functional Interface
+    @Test
+    public void testLambdaWithDependencyInjectionAndFunctionalInterface() {
+        BugCollection bugCollection = findBugsInClasses("DependencyInjectionFunctionalInterface", "MyDependency");
+        assertThat(bugCollection, containsExactly(1, snapStartBugMatcher().inClass("MyDependency").atField("random").atLine(6).build()));
+    }
+
     // TODO fix all tests using this and remove this method eventually!
     private static void toBeFixed(Executable e) {
         assertThrows(AssertionError.class, e);

--- a/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/DependencyInjectionFunctionalInterface.java
+++ b/src/test/java/software/amazon/lambda/snapstart/lambdaexamples/DependencyInjectionFunctionalInterface.java
@@ -1,0 +1,17 @@
+package software.amazon.lambda.snapstart.lambdaexamples;
+
+import java.util.function.Function;
+
+public class DependencyInjectionFunctionalInterface implements Function<String, String> {
+
+    private final MyDependency myDependency;
+
+    public DependencyInjectionFunctionalInterface(MyDependency myDependency) {
+        this.myDependency = myDependency;
+    }
+
+    @Override
+    public String apply(String s) {
+        return myDependency.toString();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-snapstart-java-rules/issues/28

*Description of changes:*

Fixed a small bug reported by a customer. the rules weren't detecting dependency injection and functional interface in combination.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
